### PR TITLE
assign "0" to points that are missing instance predictions

### DIFF
--- a/nibio_inference/merge_pt_ss_is.py
+++ b/nibio_inference/merge_pt_ss_is.py
@@ -120,6 +120,13 @@ class MergePtSsIs(object):
         # add 1 to PredInstance column
         merged_df['PredInstance'] = merged_df['PredInstance'] + 1
 
+        # Assign NaNs in PredInstance to 0. This is because the instance segmentation
+        # may not have been able to assign an instance ID to every point, so after the
+        # outer join, it is possible to have missing values in PredInstance. This causes
+        # an issue when saving the data to a .las file, as we want to cast the column to
+        # an unsigned integer type, which does not support NaNs.
+        merged_df['PredInstance'] = merged_df['PredInstance'].fillna(0)
+
         return merged_df
     
     def save(self, merged_df):


### PR DESCRIPTION
It is possible for instance predictions to contain fewer points than are present in the original points and semantic segmentation data. After outer joining, this can result `NaN`s in the `PredInstance` column of the merged dataframe.

In lieu of a potential fix of the root cause of this, this update simply assigns `0` to all missing values in the `PredInstance` column after merging (prior to saving to `.las` format).