### PR TITLE
Added link for pre-built docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Under the hood, SegmentAnyTree relies on the [torch-points3d framework](https://
 The code has been tested on a Linux machine and it relies on a docker image. The method has not been tested in a Windows environment and parts of the code (e.g. Minkowski Engine) might not be available for Windows.
 
 ### Using the docker image
+
+A pre-built docker image can be pulled from [here](https://hub.docker.com/repository/docker/donaldmaen/segment-any-tree/general)
+
 In order to run code using docker container you should edit the content of `run_docker_locally.sh` file.  You should change the following lines:
 ```
 docker run -it --gpus all \


### PR DESCRIPTION
I uploaded a pre-built version of the docker image to my docker hub and added a link to the README. I have not been able to test to make sure the image works across different machines, but I'm not sure why it wouldn't.