### PR TITLE
Fix issue in block merging that causes fusing of separate tree instances. Fixes #28

### DIFF
--- a/torch_points3d/metrics/panoptic_tracker_pointgroup_treeins.py
+++ b/torch_points3d/metrics/panoptic_tracker_pointgroup_treeins.py
@@ -450,7 +450,7 @@ class PanopticTracker(SegmentationTracker):
                     # print(len(new_has_old_idx))
                     # print(len(new_not_old_idx))
                     if len(new_has_old_idx) == 0:
-                        all_pre_ins[new_not_old_idx] = max_instance + 1
+                        all_pre_ins[new_not_old_idx] = max_instance
                         max_instance = max_instance + 1
                     elif len(new_not_old_idx) == 0:
                         continue
@@ -474,7 +474,7 @@ class PanopticTracker(SegmentationTracker):
                         if max_iou_ii > 0.1:  # th_merge:
                             all_pre_ins[new_not_old_idx] = max_iou_ii_oldlabel
                         else:
-                            all_pre_ins[new_not_old_idx] = max_instance + 1
+                            all_pre_ins[new_not_old_idx] = max_instance
                             max_instance = max_instance + 1
         return torch.from_numpy(all_pre_ins), max_instance
 


### PR DESCRIPTION
This pull request fixes a small bug in the block merging algorithm that caused tree instances located far away from each other to be fused in certain edge cases. This issue appears to only occur on relatively sparse forest plots. See #28 for a more detailed description of the problem.